### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mikemorg/8c0c6c93-7d60-4d63-aba4-6944a092b9c1/2bd35414-0974-410d-b038-a8d26b12fedd/_apis/work/boardbadge/2508254f-0b86-457f-884d-646b4983e06f)](https://dev.azure.com/mikemorg/8c0c6c93-7d60-4d63-aba4-6944a092b9c1/_boards/board/t/2bd35414-0974-410d-b038-a8d26b12fedd/Microsoft.RequirementCategory)
 <div style="text-align: center" align="center">
   <img alt="Open Sauced" src="https://i.ibb.co/7jPXt0Z/logo1-92f1a87f.png" width="300px" />
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#482](https://dev.azure.com/mikemorg/8c0c6c93-7d60-4d63-aba4-6944a092b9c1/_workitems/edit/482). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.